### PR TITLE
remove ro.vendor.build.svn sysprop

### DIFF
--- a/device-barbet.mk
+++ b/device-barbet.mk
@@ -228,3 +228,5 @@ PRODUCT_PACKAGES += \
 # sysconfig XML from stock
 PRODUCT_COPY_FILES += \
 	$(LOCAL_PATH)/product-sysconfig-stock.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/sysconfig/product-sysconfig-stock.xml
+
+PRODUCT_PROPERTY_OVERRIDES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_PROPERTY_OVERRIDES))


### PR DESCRIPTION
Value of ro.vendor.build.svn in stock OS image used by adevtool might not match the value specified here, e.g. when base AOSP tag doesn't match the tag that was used for stock OS build.

adevtool automatically adds missing properties, i.e. removal of ro.vendor.build.svn from here means that ro.vendor.build.svn sysprop value from stock OS image will be used instead.